### PR TITLE
Add check for first time publishing a new package

### DIFF
--- a/pxb-publish/CHANGELOG.md
+++ b/pxb-publish/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.1.0 (July 14, 2021)
+
+### Added
+
+-   Ability to publish a brand new package for the first time with the access flag (public) applied.
+
 ## v1.0.2 (April 27, 2021)
 
 ### Changed

--- a/pxb-publish/package.json
+++ b/pxb-publish/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@pxblue/publish",
     "description": "A script that can be used to automatically publish packages to npm.",
-    "version": "1.0.2",
+    "version": "1.1.0",
     "author": "Power Xpert Blue <pxblue@eaton.com> (https://github.com/pxblue)",
     "license": "BSD-3-Clause",
     "repository": {

--- a/pxb-publish/scripts/publish.sh
+++ b/pxb-publish/scripts/publish.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 BRANCH=dev # default
+FIRST_TIME=false # is this the first time publishing the package?
 
 # Load the package name and current version from ./package.json
 PACKAGE=`node -p "require('./package.json').name"`
@@ -18,39 +19,51 @@ done
 NPM_LATEST_VERSION=`npm show ${PACKAGE} version`
 NPM_BETA_VERSION=`npm show ${PACKAGE}@beta version`
 NPM_ALPHA_VERSION=`npm show ${PACKAGE}@alpha version`
+if [ "$NPM_LATEST_VERSION" == "" ] 
+then FIRST_TIME=true; 
+fi;
 
 # Check if this is an alpha, beta, or latest package and run the appropriate publishing command
 if grep -q "alpha" <<< "$CURRENT_VERSION";
 then
-    if ! [ $CURRENT_VERSION == $NPM_ALPHA_VERSION ];
+    if ! [ "$CURRENT_VERSION" == "$NPM_ALPHA_VERSION" ];
     then
         echo "Publishing new alpha";
-        npm publish --tag alpha
+        if [ "$FIRST_TIME" == true ]
+        then npm publish --tag alpha --access public
+        else npm publish --tag alpha
+        fi
     else
         echo "Alpha version is already published."
     fi
 elif grep -q "beta" <<< "$CURRENT_VERSION";
 then
-    if ! [ $CURRENT_VERSION == $NPM_BETA_VERSION ];
+    if ! [ "$CURRENT_VERSION" == "$NPM_BETA_VERSION" ];
     then
         echo "Publishing new beta";
-        npm publish --tag beta
+        if [ "$FIRST_TIME" = true ]
+        then npm publish --tag beta --access public
+        else npm publish --tag beta
+        fi
     else
         echo "Beta version is already published."
     fi
 else
     # If this is not the master branch, do not do any 'latest' publications
-    if ! [ $BRANCH == "master" ];
+    if ! [ "$BRANCH" == "master" ];
     then
         echo "This is not the master branch - skipping publishing."
         exit 0;
     fi
 
     # If this is the master branch (or running locally without a -b flag), allow publishing a latest package
-    if ! [ $CURRENT_VERSION == $NPM_LATEST_VERSION ];
+    if ! [ "$CURRENT_VERSION" == "$NPM_LATEST_VERSION" ];
     then
         echo "Publishing new latest";
-        npm publish
+        if [ "$FIRST_TIME" = true ]
+        then npm publish --access public
+        else npm publish
+        fi
     else
         echo "Latest version is already published."
     fi


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #19 

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Add a check for the case where we are publishing a new package for the first time (version doesn't exist in NPM to check against)
- Apply the correct access flag for first time publishes