### PR TITLE
Use first patch notes

### DIFF
--- a/blui-tag/CHANGELOG.md
+++ b/blui-tag/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
--   Fixed bug in the `parse-changelog` script where it would create Github releases using older patch notes when resolving duplicate versions. 
+-   Fixed bug in the `parse-changelog` script where it would create Github releases using older patch notes when resolving duplicate versions.
 
 ## v1.0.2 (October 14, 2021)
 

--- a/blui-tag/CHANGELOG.md
+++ b/blui-tag/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.3 (October 15, 2021)
+
+### Fixed
+
+-   Fixed bug in the `parse-changelog` script where it would create Github releases using older patch notes when resolving duplicate versions. 
+
 ## v1.0.2 (October 14, 2021)
 
 ### Changed

--- a/blui-tag/package.json
+++ b/blui-tag/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/tag",
     "description": "A script that can be used to automatically tag packages in a continuous integration pipeline.",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com> (https://github.com/brightlayer-ui)",
     "license": "BSD-3-Clause",
     "repository": {

--- a/blui-tag/scripts/parse-changelog.js
+++ b/blui-tag/scripts/parse-changelog.js
@@ -15,7 +15,6 @@ fs.readFile('CHANGELOG.md', 'utf8', (err, data) => {
     let found = false;
 
     for (const release of releases) {
-
         console.log(release);
         console.log(VERSION);
 

--- a/blui-tag/scripts/parse-changelog.js
+++ b/blui-tag/scripts/parse-changelog.js
@@ -15,8 +15,14 @@ fs.readFile('CHANGELOG.md', 'utf8', (err, data) => {
     let found = false;
 
     for (const release of releases) {
+
         console.log(release);
         console.log(VERSION);
+
+        if (found) {
+            continue;
+        }
+
         if (release.includes(VERSION)) {
             found = true;
             fs.writeFile('TAG_CHANGELOG.md', `## v${release}`, (err) => {


### PR DESCRIPTION
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- When parsing a changelog with duplicate versions, use the most-recent patch notes when creating tag release notes. 