### PR TITLE
Blui 4197 let each job set token and caller can inherit

### DIFF
--- a/.github/workflows/blui-labels.yml
+++ b/.github/workflows/blui-labels.yml
@@ -5,9 +5,6 @@ on:
     types:
       - opened
   workflow_call:
-    secrets:
-      token:
-        required: true
 
 permissions:
   pull-requests: write

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,8 +1,10 @@
 name: 'Comment on PR'
 on:
   pull_request_target:
+    types:
+      - opened
     branches:
-      - master
+      - 'master'
   workflow_call:
 
 permissions:


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4197 (update)# .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- adjust pull request target to use types (open) then set branch (master) for commenter
- adjust the workflow call to not require secret on the workflow itself, rather just let each job to contain the secret
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
